### PR TITLE
Revert "use fullname where this can be extracted: add google format version (#6)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
 
     <cleanthat.version>2.17</cleanthat.version>
     <error-prone.version>2.24.1</error-prone.version>
-    <google-java-format.version>1.19.2</google-java-format.version>
 
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>


### PR DESCRIPTION
This reverts commit e6d2d60949bdf227fba2fb520526092c37a56f6d.

# Description

Reverting the change, as this introduced the following security risk:

Imagine the situation the user `hbase/hbase-prod.prod-namespace.svc.cluster.local@CLUSTER.LOCAL` access HDFS, the GroupMapper will be asked for the groups of the user `hbase` and returns the groups `["prod"]`. This response will be cached by HDFS by the key `hbase`. If a different user  `hbase/hbase-dev.dev-namespace.svc.cluster.local@CLUSTER.LOCAL` accesses HDFS a few seconds later the mapping `hbase` ->  `["prod"]` is still cached and HDFS will falsely assume the `hbase-dev` HBase is in the `prod` group!

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
```

```[tasklist]
# Acceptance
- [ ] Proper release label has been added
```

