### PR TITLE
feat: generate CycloneDX SBOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM docker.stackable.tech/stackable/hadoop:3.3.6-stackable0.0.0-dev
 
 COPY --chown=stackable:stackable ./hdfs-utils-*.jar /stackable/hadoop/share/hadoop/tools/lib/
+COPY --chown=stackable:stackable ./bom.json /stackable/hadoop/share/hadoop/tools/lib/hdfs-utils.cdx.json

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.8.0</version>
+        <configuration>
+          <projectType>application</projectType>
+          <schemaVersion>1.5</schemaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeBom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This enables the generation of a CycloneDX SBOM as part of the build process. Needed for https://github.com/stackabletech/issues/issues/614

Tested locally, result looks good.