### PR TITLE
Performance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump okio to 1.17.6 to get rid of CVE-2023-3635 ([#46])
-- Performance fixes ([#50#])
+- Performance fixes ([#50])
 
 [#46]: https://github.com/stackabletech/hdfs-utils/pull/46
-[#50]: https://github.com/stackabletech/hdfs-utils/pull/50 
+[#50]: https://github.com/stackabletech/hdfs-utils/pull/50
 
 ## [0.3.0] - 2024-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump okio to 1.17.6 to get rid of CVE-2023-3635 ([#46])
+- Performance fixes ([#50#])
 
 [#46]: https://github.com/stackabletech/hdfs-utils/pull/46
+[#50]: https://github.com/stackabletech/hdfs-utils/pull/50 
 
 ## [0.3.0] - 2024-07-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM docker.stackable.tech/stackable/hadoop:3.3.6-stackable0.0.0-dev
+FROM docker.stackable.tech/stackable/hadoop:3.4.0-stackable0.0.0-dev
 
-COPY --chown=stackable:stackable ./hdfs-utils-*.jar /stackable/hadoop/share/hadoop/tools/lib/
-COPY --chown=stackable:stackable ./bom.json /stackable/hadoop/share/hadoop/tools/lib/hdfs-utils.cdx.json
+# Remove existing hdfs-utils jars, so we can ship our custom one
+RUN rm -f /stackable/hadoop/share/hadoop/common/lib/hdfs-utils-*.jar
+RUN rm -f /stackable/hadoop/share/hadoop/tools/lib/hdfs-utils-*.jar
+
+COPY --chown=stackable:stackable ./hdfs-utils-*.jar /stackable/hadoop/share/hadoop/common/lib/
+COPY --chown=stackable:stackable ./bom.json /stackable/hadoop/share/hadoop/common/lib/hdfs-utils.cdx.json

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <!-- Tip: Use "mvn versions:display-dependency-updates" to check for updates -->
     <cleanthat.version>2.17</cleanthat.version>
     <error-prone.version>2.28.0</error-prone.version>
     <google-java-format.version>1.19.2</google-java-format.version>

--- a/src/main/java/tech/stackable/hadoop/StackableAccessControlEnforcer.java
+++ b/src/main/java/tech/stackable/hadoop/StackableAccessControlEnforcer.java
@@ -7,6 +7,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
@@ -19,153 +25,202 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.Objects;
-
-// As of 2024-02-09 INodeAttributeProvider.AccessControlEnforcer has two functions: The old - deprecated -
-// checkPermission and the new checkPermissionWithContext. HDFS uses reflection to check if the authorizer
-// supports the new API (which we do) and uses that in this case. This is also indicated by the log statement
-// "Use the new authorization provider API" during startup, see https://github.com/apache/hadoop/blob/50d256ef3c2531563bc6ba96dec6b78e154b4697/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java#L245
-// FSPermissionChecker (as a caller of the AccessControlEnforcer interface) has a ThreadLocal operationType, which
-// needs to be set to e.g. "create", "delete" or "rename" prior to calling the FSPermissionChecker.checkPermission
-// function, as it will actually check if operationType is null and will still use the old API in this case! But the old
-// API does not have the information about the operationType, which makes it hard to impossible to authorize the request.
-// As a consequence we only support the new API and will make sure no HDFS code path calls the old API. This required
-// minor patches to HDFS, as it was e.g. missing a call to FSPermissionChecker.setOperationType("create") in
+// As of 2024-02-09 INodeAttributeProvider.AccessControlEnforcer has two functions: The old -
+// deprecated -
+// checkPermission and the new checkPermissionWithContext. HDFS uses reflection to check if the
+// authorizer
+// supports the new API (which we do) and uses that in this case. This is also indicated by the log
+// statement
+// "Use the new authorization provider API" during startup, see
+// https://github.com/apache/hadoop/blob/50d256ef3c2531563bc6ba96dec6b78e154b4697/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java#L245
+// FSPermissionChecker (as a caller of the AccessControlEnforcer interface) has a ThreadLocal
+// operationType, which
+// needs to be set to e.g. "create", "delete" or "rename" prior to calling the
+// FSPermissionChecker.checkPermission
+// function, as it will actually check if operationType is null and will still use the old API in
+// this case! But the old
+// API does not have the information about the operationType, which makes it hard to impossible to
+// authorize the request.
+// As a consequence we only support the new API and will make sure no HDFS code path calls the old
+// API. This required
+// minor patches to HDFS, as it was e.g. missing a call to
+// FSPermissionChecker.setOperationType("create") in
 // FSNamesystem.startFileInt (this claim needs to be validated though).
-public class StackableAccessControlEnforcer implements INodeAttributeProvider.AccessControlEnforcer {
+public class StackableAccessControlEnforcer
+    implements INodeAttributeProvider.AccessControlEnforcer {
 
-    private static final Logger LOG = LoggerFactory.getLogger(StackableAccessControlEnforcer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StackableAccessControlEnforcer.class);
 
-    public static final String OPA_POLICY_URL_PROP = "hadoop.security.authorization.opa.policy.url";
+  public static final String OPA_POLICY_URL_PROP = "hadoop.security.authorization.opa.policy.url";
 
-    private final HttpClient httpClient = HttpClient.newHttpClient();
-    private final ObjectMapper json;
-    private URI opaUri;
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+  private final ObjectMapper json;
+  private URI opaUri;
 
-    public StackableAccessControlEnforcer() {
-        LOG.debug("Starting StackableAccessControlEnforcer");
+  public StackableAccessControlEnforcer() {
+    LOG.debug("Starting StackableAccessControlEnforcer");
 
-        // Guaranteed to be only called once (Effective Java: Item 3)
-        Configuration configuration = HadoopConfigSingleton.INSTANCE.getConfiguration();
+    // Guaranteed to be only called once (Effective Java: Item 3)
+    Configuration configuration = HadoopConfigSingleton.INSTANCE.getConfiguration();
 
-        String opaPolicyUrl = configuration.get(OPA_POLICY_URL_PROP);
-        if (opaPolicyUrl == null) {
-            throw new OpaException.UriMissing(OPA_POLICY_URL_PROP);
-        }
-
-        try {
-            this.opaUri = URI.create(opaPolicyUrl);
-        } catch (Exception e) {
-            throw new OpaException.UriInvalid(opaUri, e);
-        }
-
-        this.json = new ObjectMapper()
-                // OPA server can send other fields, such as `decision_id`` when enabling decision logs
-                // We could add all the fields we *currently* know, but it's more future-proof to ignore any unknown fields
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                // Previously we were getting
-                // Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.apache.hadoop.hdfs.util.EnumCounters and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: tech.stackable.HdfsOpaAccessControlEnforcer$ContextWrapper["inodeAttrs"]->org.apache.hadoop.hdfs.server.namenode.INodeDirectory[0]->org.apache.hadoop.hdfs.server.namenode.INodeDirectory["features"]->org.apache.hadoop.hdfs.server.namenode.DirectoryWithQuotaFeature[0]->org.apache.hadoop.hdfs.server.namenode.DirectoryWithQuotaFeature["spaceConsumed"]->org.apache.hadoop.hdfs.server.namenode.QuotaCounts["typeSpaces"])
-                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-                // Only include the needed fields. HDFS has many classes with even more circular reference to remove
-                .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
-                .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY)
-                .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.PUBLIC_ONLY)
-                // We need to remove some circular pointers (e.g. root -> children[0] -> parent -> root)
-                // Otherwise we get com.fasterxml.jackson.databind.JsonMappingException: Infinite recursion (StackOverflowError)
-                .addMixIn(DatanodeDescriptor.class, DatanodeDescriptorMixin.class);
-
-        LOG.debug("Started HdfsOpaAccessControlEnforcer");
+    String opaPolicyUrl = configuration.get(OPA_POLICY_URL_PROP);
+    if (opaPolicyUrl == null) {
+      throw new OpaException.UriMissing(OPA_POLICY_URL_PROP);
     }
 
-    private static class OpaQueryResult {
-        // Boxed Boolean to detect not-present vs explicitly false
-        public Boolean result;
+    try {
+      opaUri = URI.create(opaPolicyUrl);
+    } catch (Exception e) {
+      throw new OpaException.UriInvalid(opaUri, e);
     }
 
-    @Override
-    public void checkPermission(String fsOwner, String supergroup,
-                                UserGroupInformation ugi, INodeAttributes[] inodeAttrs,
-                                INode[] inodes, byte[][] pathByNameArr, int snapshotId, String path,
-                                int ancestorIndex, boolean doCheckOwner, FsAction ancestorAccess,
-                                FsAction parentAccess, FsAction access, FsAction subAccess,
-                                boolean ignoreEmptyDir) throws AccessControlException {
-        LOG.warn("checkPermission called");
+    json =
+        new ObjectMapper()
+            // OPA server can send other fields, such as `decision_id`` when enabling decision logs
+            // We could add all the fields we *currently* know, but it's more future-proof to ignore
+            // any unknown fields
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            // Previously we were getting
+            // Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No
+            // serializer found for class org.apache.hadoop.hdfs.util.EnumCounters and no properties
+            // discovered to create BeanSerializer (to avoid exception, disable
+            // SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain:
+            // tech.stackable.HdfsOpaAccessControlEnforcer$ContextWrapper["inodeAttrs"]->org.apache.hadoop.hdfs.server.namenode.INodeDirectory[0]->org.apache.hadoop.hdfs.server.namenode.INodeDirectory["features"]->org.apache.hadoop.hdfs.server.namenode.DirectoryWithQuotaFeature[0]->org.apache.hadoop.hdfs.server.namenode.DirectoryWithQuotaFeature["spaceConsumed"]->org.apache.hadoop.hdfs.server.namenode.QuotaCounts["typeSpaces"])
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            // Only include the needed fields. HDFS has many classes with even more circular
+            // reference to remove
+            .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY)
+            .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.PUBLIC_ONLY)
+            // We need to remove some circular pointers (e.g. root -> children[0] -> parent -> root)
+            // Otherwise we get com.fasterxml.jackson.databind.JsonMappingException: Infinite
+            // recursion (StackOverflowError)
+            .addMixIn(DatanodeDescriptor.class, DatanodeDescriptorMixin.class);
 
-        new Throwable().printStackTrace();
-        throw new AccessControlException("The HdfsOpaAccessControlEnforcer does not implement the old checkPermission API. " +
-                "This should not happen, as all HDFS code paths should call the new API. " +
-                "I dumped the stack trace for you (check active namenode logs), so you can figure out which code path it was. " +
-                "Please report all of that to author of the OPA authorizer (We don't have a stable GitHub link yet, sorry!) " +
-                "Passed arguments: " +
-                "fsOwner: " + fsOwner + ", supergroup: " + supergroup + ", ugi: " + ugi + ", path: " + path + ", ancestorIndex:" + ancestorIndex +
-                ", doCheckOwner: " + doCheckOwner + ", ancestorAccess: " + ancestorAccess + ", parentAccess: " + parentAccess +
-                ", subAccess: " + subAccess + ", ignoreEmptyDir: " + ignoreEmptyDir);
+    LOG.debug("Started HdfsOpaAccessControlEnforcer");
+  }
+
+  private static class OpaQueryResult {
+    // Boxed Boolean to detect not-present vs explicitly false
+    public Boolean result;
+  }
+
+  @Override
+  public void checkPermission(
+      String fsOwner,
+      String supergroup,
+      UserGroupInformation ugi,
+      INodeAttributes[] inodeAttrs,
+      INode[] inodes,
+      byte[][] pathByNameArr,
+      int snapshotId,
+      String path,
+      int ancestorIndex,
+      boolean doCheckOwner,
+      FsAction ancestorAccess,
+      FsAction parentAccess,
+      FsAction access,
+      FsAction subAccess,
+      boolean ignoreEmptyDir)
+      throws AccessControlException {
+    LOG.warn("checkPermission called");
+
+    new Throwable().printStackTrace();
+    throw new AccessControlException(
+        "The HdfsOpaAccessControlEnforcer does not implement the old checkPermission API. "
+            + "This should not happen, as all HDFS code paths should call the new API. "
+            + "I dumped the stack trace for you (check active namenode logs), so you can figure out which code path it was. "
+            + "Please report all of that to author of the OPA authorizer by creating an issue in our repo: https://github.com/stackabletech/hdfs-utils"
+            + "Passed arguments: "
+            + "fsOwner: "
+            + fsOwner
+            + ", supergroup: "
+            + supergroup
+            + ", ugi: "
+            + ugi
+            + ", path: "
+            + path
+            + ", ancestorIndex:"
+            + ancestorIndex
+            + ", doCheckOwner: "
+            + doCheckOwner
+            + ", ancestorAccess: "
+            + ancestorAccess
+            + ", parentAccess: "
+            + parentAccess
+            + ", subAccess: "
+            + subAccess
+            + ", ignoreEmptyDir: "
+            + ignoreEmptyDir);
+  }
+
+  @Override
+  public void checkPermissionWithContext(INodeAttributeProvider.AuthorizationContext authzContext)
+      throws AccessControlException {
+    OpaAllowQuery query = new OpaAllowQuery(new OpaAllowQuery.OpaAllowQueryInput(authzContext));
+
+    String body;
+    try {
+      body = json.writeValueAsString(query);
+    } catch (JsonProcessingException e) {
+      throw new OpaException.SerializeFailed(e);
     }
 
-    @Override
-    public void checkPermissionWithContext(INodeAttributeProvider.AuthorizationContext authzContext) throws AccessControlException {
-        OpaAllowQuery query = new OpaAllowQuery(new OpaAllowQuery.OpaAllowQueryInput(authzContext));
-
-        String body;
-        try {
-            body = json.writeValueAsString(query);
-        } catch (JsonProcessingException e) {
-            throw new OpaException.SerializeFailed(e);
-        }
-
-        String prettyPrinted;
-        try {
-            prettyPrinted = json.writerWithDefaultPrettyPrinter().writeValueAsString(query);
-        } catch (JsonProcessingException e) {
-            LOG.error("Could not pretty print the following request body (but non-pretty print did work): {}", body);
-            throw new OpaException.SerializeFailed(e);
-        }
-
-        LOG.debug("Request body:\n{}", prettyPrinted);
-        HttpResponse<String> response = null;
-        try {
-            response =
-                    httpClient.send(
-                            HttpRequest.newBuilder(opaUri)
-                                    .header("Content-Type", "application/json")
-                                    .POST(HttpRequest.BodyPublishers.ofString(body))
-                                    .build(),
-                            HttpResponse.BodyHandlers.ofString());
-            LOG.debug("Opa response: {}", response.body());
-        } catch (Exception e) {
-            LOG.error(e.getMessage());
-            throw new OpaException.QueryFailed(e);
-        }
-
-        switch (Objects.requireNonNull(response).statusCode()) {
-            case 200:
-                break;
-            case 404:
-                throw new OpaException.EndPointNotFound(opaUri.toString());
-            default:
-                throw new OpaException.OpaServerError(query.toString(), response);
-        }
-
-        OpaQueryResult result;
-        try {
-            result = json.readValue(response.body(), OpaQueryResult.class);
-        } catch (JsonProcessingException e) {
-            throw new OpaException.DeserializeFailed(e);
-        }
-
-        if (result.result == null || !result.result) {
-            throw new AccessControlException("OPA denied the request");
-        }
+    if (LOG.isDebugEnabled()) {
+      String prettyPrinted;
+      try {
+        prettyPrinted = json.writerWithDefaultPrettyPrinter().writeValueAsString(query);
+      } catch (JsonProcessingException e) {
+        LOG.error(
+            "Could not pretty print the following request body (but non-pretty print did work): {}",
+            body);
+        throw new OpaException.SerializeFailed(e);
+      }
+      LOG.debug("Request body:\n{}", prettyPrinted);
     }
 
-    private abstract static class DatanodeDescriptorMixin {
-        @JsonIgnore
-        abstract INode getParent();
-        @JsonIgnore
-        abstract DatanodeStorageInfo[] getStorageInfos();
+    HttpResponse<String> response;
+    try {
+      response =
+          HTTP_CLIENT.send(
+              HttpRequest.newBuilder(opaUri)
+                  .header("Content-Type", "application/json")
+                  .POST(HttpRequest.BodyPublishers.ofString(body))
+                  .build(),
+              HttpResponse.BodyHandlers.ofString());
+      LOG.debug("OPA response: {}", response.body());
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      throw new OpaException.QueryFailed(e);
     }
+
+    switch (Objects.requireNonNull(response).statusCode()) {
+      case 200:
+        break;
+      case 404:
+        throw new OpaException.EndPointNotFound(opaUri.toString());
+      default:
+        throw new OpaException.OpaServerError(query.toString(), response);
+    }
+
+    OpaQueryResult result;
+    try {
+      result = json.readValue(response.body(), OpaQueryResult.class);
+    } catch (JsonProcessingException e) {
+      throw new OpaException.DeserializeFailed(e);
+    }
+
+    if (result.result == null || !result.result) {
+      throw new AccessControlException("OPA denied the request");
+    }
+  }
+
+  private abstract static class DatanodeDescriptorMixin {
+    @JsonIgnore
+    abstract INode getParent();
+
+    @JsonIgnore
+    abstract DatanodeStorageInfo[] getStorageInfos();
+  }
 }

--- a/src/main/java/tech/stackable/hadoop/StackableAuthorizer.java
+++ b/src/main/java/tech/stackable/hadoop/StackableAuthorizer.java
@@ -7,26 +7,30 @@ import org.slf4j.LoggerFactory;
 
 public class StackableAuthorizer extends INodeAttributeProvider {
 
-    private static final Logger LOG = LoggerFactory.getLogger(StackableAuthorizer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StackableAuthorizer.class);
 
-    @Override
-    public void start() {
-        LOG.debug("Starting HdfsOpaAuthorizer");
-    }
+  private static final StackableAccessControlEnforcer ENFORCER =
+      new StackableAccessControlEnforcer();
 
-    @Override
-    public void stop() {
-        LOG.debug("Stopping HdfsOpaAuthorizer");
-    }
+  @Override
+  public void start() {
+    LOG.debug("Starting HdfsOpaAuthorizer");
+  }
 
-    @Override
-    public INodeAttributes getAttributes(String[] strings, INodeAttributes iNodeAttributes) {
-        // No special attributes needed
-        return iNodeAttributes;
-    }
+  @Override
+  public void stop() {
+    LOG.debug("Stopping HdfsOpaAuthorizer");
+  }
 
-    @Override
-    public AccessControlEnforcer getExternalAccessControlEnforcer(AccessControlEnforcer defaultEnforcer) {
-        return new StackableAccessControlEnforcer();
-    }
+  @Override
+  public INodeAttributes getAttributes(String[] strings, INodeAttributes iNodeAttributes) {
+    // No special attributes needed
+    return iNodeAttributes;
+  }
+
+  @Override
+  public AccessControlEnforcer getExternalAccessControlEnforcer(
+      AccessControlEnforcer defaultEnforcer) {
+    return ENFORCER;
+  }
 }

--- a/src/main/java/tech/stackable/hadoop/StackableGroupMapper.java
+++ b/src/main/java/tech/stackable/hadoop/StackableGroupMapper.java
@@ -8,12 +8,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.HashMap;
+import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.GroupMappingServiceProvider;
 import org.slf4j.Logger;
@@ -23,7 +20,8 @@ public class StackableGroupMapper implements GroupMappingServiceProvider {
 
   public static final String OPA_MAPPING_URL_PROP = "hadoop.security.group.mapping.opa.policy.url";
   private static final Logger LOG = LoggerFactory.getLogger(StackableGroupMapper.class);
-  private final HttpClient httpClient = HttpClient.newHttpClient();
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
   private final ObjectMapper json;
   private URI opaUri;
 
@@ -80,13 +78,13 @@ public class StackableGroupMapper implements GroupMappingServiceProvider {
     HttpResponse<String> response = null;
     try {
       response =
-          httpClient.send(
+          HTTP_CLIENT.send(
               HttpRequest.newBuilder(opaUri)
                   .header("Content-Type", "application/json")
                   .POST(HttpRequest.BodyPublishers.ofString(body))
                   .build(),
               HttpResponse.BodyHandlers.ofString());
-      LOG.debug("Opa response: {}", response.body());
+      LOG.debug("OPA response: {}", response.body());
     } catch (Exception e) {
       LOG.error(e.getMessage());
       throw new OpaException.QueryFailed(e);

--- a/test/stack/20-hdfs.yaml
+++ b/test/stack/20-hdfs.yaml
@@ -25,7 +25,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.3.6
+    productVersion: 3.4.0
     custom: hdfs # Will be overwritten by Tilt
     pullPolicy: IfNotPresent
   clusterConfig:

--- a/test/stack/30-test-hdfs-permissions.yaml
+++ b/test/stack/30-test-hdfs-permissions.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: test-hdfs-permissions
-          image: docker.stackable.tech/stackable/hadoop:3.3.6-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/hadoop:3.4.0-stackable0.0.0-dev
           env:
             - name: HADOOP_CONF_DIR
               value: /stackable/conf/hdfs

--- a/test/stack/31-benchmark-shell.yaml
+++ b/test/stack/31-benchmark-shell.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: benchmark-shell
+spec:
+  template:
+    spec:
+      containers:
+        - name: benchmark-shell
+          image: docker.stackable.tech/stackable/hadoop:3.4.0-stackable0.0.0-dev
+          env:
+            - name: HADOOP_CONF_DIR
+              value: /stackable/conf/hdfs
+            - name: KRB5_CONFIG
+              value: /stackable/kerberos/krb5.conf
+            - name: HADOOP_OPTS
+              value: -Djava.security.krb5.conf=/stackable/kerberos/krb5.conf
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -ex
+              klist -k /stackable/kerberos/keytab
+
+              log_in () { kdestroy; kinit -kt /stackable/kerberos/keytab $1/benchmark-shell.default.svc.cluster.local; }
+
+              log_in admin
+
+              bin/hdfs dfs -mkdir -p /bench
+              bin/hdfs dfs -ls /bench
+
+              # for i in $(seq 0 10); do echo "Creating $i" && bin/hdfs dfs -put -f /etc/hosts /bench/$i; done
+
+              # Watch out for the exact command you are using! (e.g. don't use "du -h /""). Checl the NameNode logs to
+              # make sure you actually produce enough OPA calls.
+              # time bin/hdfs dfs -du -h /bench
+
+              # So that you can run the benchmark manually
+              sleep infinity
+
+              exit 0
+          volumeMounts:
+            - name: hdfs-config
+              mountPath: /stackable/conf/hdfs
+            - name: kerberos
+              mountPath: /stackable/kerberos
+      volumes:
+        - name: hdfs-config
+          configMap:
+            name: simple-hdfs
+        - name: kerberos
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                annotations:
+                  secrets.stackable.tech/class: kerberos-default
+                  secrets.stackable.tech/scope: service=benchmark-shell
+                  secrets.stackable.tech/kerberos.service.names: admin,alice,bob
+              spec:
+                storageClassName: secrets.stackable.tech
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: "1"
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsUser: 1000
+      restartPolicy: OnFailure

--- a/test/topology-provider/stack/03-hdfs.yaml
+++ b/test/topology-provider/stack/03-hdfs.yaml
@@ -25,7 +25,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.3.6
+    productVersion: 3.4.0
     custom: hdfs # updated by tilt
     pullPolicy: IfNotPresent
   clusterConfig:


### PR DESCRIPTION
# Description

- HTTP_CLIENT is now static and includes a connection timeout
- StackableAuthorizer only constructs a single instance of StackableAccessControlEnforcer
- StackableAccessControlEnforcer does not serialize to JSON twice anymore
- Spotless formatting applied to code

## Definition of Done Checklist

```[tasklist]
# Reviewer
- [ ] Changelog updated
```

```[tasklist]
# Acceptance
- [ ] Proper release label has been added
```

