### PR TITLE
chore: Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-11-05
+
 ### Changed
 
 - BREAKING: Only send a subset of the fields sufficient for most use-cases to OPA for performance reasons.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>tech.stackable</groupId>
   <artifactId>hdfs-utils</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
 
   <name>Apache Hadoop HDFS utils</name>
   <url>https://github.com/stackabletech/hdfs-utils/</url>


### PR DESCRIPTION
# Description

### Changed

- BREAKING: Only send a subset of the fields sufficient for most use-cases to OPA for performance reasons.
  The old behavior of sending all fields can be restored by setting `hadoop.security.authorization.opa.extended-requests`
  to `true` ([#49]).
- Performance fixes ([#50])
- Updates various dependencies and do a full spotless run. This will now require JDK 17 or later to build
  (required by later error-prone versions), the build target is still Java 11 [#51]
- Bump okio to 1.17.6 to get rid of CVE-2023-3635 ([#46])

### Fixed

- Set path to `/` when the operation `contentSummary` is called on `/`. Previously path was set to `null` ([#49]).

[#46]: https://github.com/stackabletech/hdfs-utils/pull/46
[#49]: https://github.com/stackabletech/hdfs-utils/pull/49
[#50]: https://github.com/stackabletech/hdfs-utils/pull/50
[#51]: https://github.com/stackabletech/hdfs-utils/pull/51

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
```

```[tasklist]
# Acceptance
- [ ] Proper release label has been added
```

